### PR TITLE
Remove GraphClient from the Compute.Test Authentication

### DIFF
--- a/src/ResourceManager/Compute/Commands.Compute.Test/Common/ComputeTestController.cs
+++ b/src/ResourceManager/Compute/Commands.Compute.Test/Common/ComputeTestController.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Commands.Compute.Test.ScenarioTests
             NetworkResourceProviderClient = GetNetworkResourceProviderClient();
             ComputeManagementClient = GetComputeManagementClient();
             AuthorizationManagementClient = GetAuthorizationManagementClient();
-            GraphClient = GetGraphClient();
+            // GraphClient = GetGraphClient();
 
             helper.SetupManagementClients(
                 ResourceManagementClient,
@@ -171,8 +171,8 @@ namespace Microsoft.Azure.Commands.Compute.Test.ScenarioTests
                 //eventsClient,
                 NetworkResourceProviderClient,
                 ComputeManagementClient,
-                AuthorizationManagementClient,
-                GraphClient);
+                AuthorizationManagementClient);
+                // GraphClient);
         }
 
         private GraphRbacManagementClient GetGraphClient()


### PR DESCRIPTION
AAD Graph client is not working with Service Principal authentication. Since the compute doesn't use graph client, we should remove it so that runners can work with dev branch as well. 
