### PR TITLE
Adding RunnerTests.cs to run runner tests using Access Token

### DIFF
--- a/src/ResourceManager/Compute/Commands.Compute.Test/Commands.Compute.Test.csproj
+++ b/src/ResourceManager/Compute/Commands.Compute.Test/Commands.Compute.Test.csproj
@@ -167,6 +167,7 @@
     <Compile Include="ScenarioTests\ComputeCloudExceptionTests.cs" />
     <Compile Include="ScenarioTests\DiagnosticsExtensionTests.cs" />
     <Compile Include="ScenarioTests\DscExtensionTests.cs" />
+    <Compile Include="ScenarioTests\RunnerTests.cs" />
     <Compile Include="ScenarioTests\VirtualMachineBootDiagnosticsTests.cs" />
     <Compile Include="ScenarioTests\VMDynamicTests.cs" />
     <Compile Include="ScenarioTests\VirtualMachineProfileTests.cs" />
@@ -235,6 +236,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="ScenarioTests\Generated\VirtualMachineDynamicTest3.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="ScenarioTests\RunnerTests.csv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="ScenarioTests\VirtualMachineBootDiagnosticsTests.ps1">

--- a/src/ResourceManager/Compute/Commands.Compute.Test/ScenarioTests/RunnerTests.cs
+++ b/src/ResourceManager/Compute/Commands.Compute.Test/ScenarioTests/RunnerTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Commands.Compute.Test.ScenarioTests
             var mode = Environment.GetEnvironmentVariable("AZURE_TEST_MODE");
             var csmAuth = Environment.GetEnvironmentVariable("TEST_CSM_ORGID_AUTHENTICATION");
 
-            if (mode.ToLower() != "record")
+            if (mode == null || csmAuth == null || mode.ToLower() != "record")
             {
                 return;
             }
@@ -32,7 +32,6 @@ namespace Microsoft.Azure.Commands.Compute.Test.ScenarioTests
 
             var authenticationContext = new AuthenticationContext("https://login.windows.net/" + testEnv.Tenant);
             var credential = new ClientCredential(testEnv.ClientId, envDictionary["ApplicationSecret"]);
-
 
             var result = authenticationContext.AcquireToken("https://management.core.windows.net/", clientCredential: credential);
             Assert.NotNull(result.AccessToken);

--- a/src/ResourceManager/Compute/Commands.Compute.Test/ScenarioTests/RunnerTests.cs
+++ b/src/ResourceManager/Compute/Commands.Compute.Test/ScenarioTests/RunnerTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
+using Xunit;
+
+namespace Microsoft.Azure.Commands.Compute.Test.ScenarioTests
+{
+    public class RunnerTests
+    {
+        [Fact]
+        public void ExecuteRunnerTests()
+        {
+            var mode = Environment.GetEnvironmentVariable("AZURE_TEST_MODE");
+            var csmAuth = Environment.GetEnvironmentVariable("TEST_CSM_ORGID_AUTHENTICATION");
+
+            if (mode.ToLower() != "record")
+            {
+                return;
+            }
+
+            Assert.False(string.IsNullOrEmpty(csmAuth));
+            Assert.True(csmAuth.Contains("AADTenant"));
+
+            var envDictionary = TestUtilities.ParseConnectionString(csmAuth);
+            var testEnv = new TestEnvironment(envDictionary);
+            Assert.NotNull(testEnv.Tenant);
+            Assert.NotNull(testEnv.SubscriptionId);
+            Assert.NotNull(testEnv.ClientId);
+            Assert.True(envDictionary.ContainsKey("ApplicationSecret"));
+
+            var authenticationContext = new AuthenticationContext("https://login.windows.net/" + testEnv.Tenant);
+            var credential = new ClientCredential(testEnv.ClientId, envDictionary["ApplicationSecret"]);
+
+
+            var result = authenticationContext.AcquireToken("https://management.core.windows.net/", clientCredential: credential);
+            Assert.NotNull(result.AccessToken);
+            envDictionary["RawToken"] = result.AccessToken;
+
+            FixCSMAuthEnvVariable(envDictionary);
+
+            Console.WriteLine(Environment.GetEnvironmentVariable("TEST_CSM_ORGID_AUTHENTICATION"));
+
+            var testFile = File.ReadAllLines("ScenarioTests\\RunnerTests.csv");
+            foreach (var line in testFile)
+            {
+                var tokens = line.Split(';');
+                var className = tokens[0];
+                var type = Type.GetType(className);
+                var constructorInfo = type.GetConstructor(Type.EmptyTypes);
+                for (int i = 1; i < tokens.Length; i++)
+                {
+                    var method = tokens[i];
+                    var testClassInstance = constructorInfo.Invoke(new object[] {});
+                    var testMethod = type.GetMethod(method);
+
+                    testMethod.Invoke(testClassInstance, new object[] {});
+                }
+            }
+        }
+
+        private void FixCSMAuthEnvVariable(IDictionary<string, string> envDictionary)
+        {
+            var str = string.Empty;
+            foreach (var entry in envDictionary)
+            {
+                if (entry.Key != "AADClientId" && entry.Key != "ApplicationSecret")
+                {
+                    str += string.Format("{0}={1};", entry.Key, entry.Value);
+                }
+            }
+
+            Environment.SetEnvironmentVariable("TEST_CSM_ORGID_AUTHENTICATION", str);
+        }
+    }
+}

--- a/src/ResourceManager/Compute/Commands.Compute.Test/ScenarioTests/RunnerTests.csv
+++ b/src/ResourceManager/Compute/Commands.Compute.Test/ScenarioTests/RunnerTests.csv
@@ -1,0 +1,4 @@
+﻿Microsoft.Azure.Commands.Compute.Test.ScenarioTests.AvailabilitySetTests;TestAvailabilitySet
+Microsoft.Azure.Commands.Compute.Test.ScenarioTests.ComputeCloudExceptionTests;RunComputeCloudExceptionTests
+Microsoft.Azure.Commands.Compute.Test.ScenarioTests.VirtualMachineTests;TestLinuxVirtualMachine
+Microsoft.Azure.Commands.Compute.Test.ScenarioTests.VirtualMachineProfileTests;TestVirtualMachineProfile

--- a/src/ResourceManager/Compute/Commands.Compute.Test/ScenarioTests/RunnerTests.csv
+++ b/src/ResourceManager/Compute/Commands.Compute.Test/ScenarioTests/RunnerTests.csv
@@ -2,3 +2,4 @@
 Microsoft.Azure.Commands.Compute.Test.ScenarioTests.ComputeCloudExceptionTests;RunComputeCloudExceptionTests
 Microsoft.Azure.Commands.Compute.Test.ScenarioTests.VirtualMachineTests;TestLinuxVirtualMachine
 Microsoft.Azure.Commands.Compute.Test.ScenarioTests.VirtualMachineProfileTests;TestVirtualMachineProfile
+Microsoft.Azure.Commands.Compute.Test.ScenarioTests.VMDynamicTests;RunVMDynamicTests


### PR DESCRIPTION
It uses the Service Principal set in the environment variable to request a AccessToken for authentication.
